### PR TITLE
Import PDFDocument from new location, see #14

### DIFF
--- a/src/slate/slate.py
+++ b/src/slate/slate.py
@@ -5,7 +5,11 @@ from pdfminer.pdfinterp import PDFResourceManager
 from pdfminer.pdfinterp import PDFPageInterpreter as PI
 from pdfminer.pdfdevice import PDFDevice
 from pdfminer.converter import TextConverter
-from pdfminer.pdfdocument import PDFDocument
+try:
+    from pdfminer.pdfparser import PDFDocument
+except ImportError:
+    from pdfminer.pdfdocument import PDFDocument
+
 from pdfminer.pdfpage import PDFPage
 
 import utils


### PR DESCRIPTION
This enables backwards compatibility to previous versions of pdfminer. It should resolve the ImportErrors.
