### PR TITLE
Small typo in slate.py ,pdfpage to pdfparser

### DIFF
--- a/src/slate/slate.py
+++ b/src/slate/slate.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     from pdfminer.pdfdocument import PDFDocument
 
-from pdfminer.pdfpage import PDFPage
+from pdfminer.pdfparser import PDFPage
 
 import utils
 


### PR DESCRIPTION
A small typo in slate.py , instead of  pdfminer.pdfpage it is pdfminer.pdfparser.
at line 16, 
from pdfminer.pdfparser import PDFPage