### PR TITLE
Now with Python3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,14 @@
 
 from setuptools import setup, find_packages
 
+import sys
+PYTHON_3 = sys.version_info[0] == 3
+if PYTHON_3:
+    pdfminer = 'pdfminer3k'
+else:
+    pdfminer = 'pdfminer'
+
+
 setup(name='slate',
       version='0.4.1',
       description='Extract text from PDF documents easily.',
@@ -12,7 +20,7 @@ setup(name='slate',
       exclude_package_data={'': ['.gitignore']},
       packages=find_packages('src'),
       package_dir={'': 'src'},
-      requires=['pdfminer'],
+      requires=[pdfminer],
       install_requires=['distribute'],
       classifiers= [
         'Development Status :: 4 - Beta',

--- a/src/slate/__init__.py
+++ b/src/slate/__init__.py
@@ -1,13 +1,13 @@
 #! /usr/env/bin python
 
-""" 
+"""
 slate provides a convenient interface to PDFMiner[1].
 
 Intializing a slate.PDF object will provide you with
 the text from the source file as a list of pages. So,
 a five page PDF file will have a range of 0-4.
 
-    >>> with open('example.pdf', 'rb') as f: 
+    >>> with open('example.pdf', 'rb') as f:
     ...    PDF(f) #doctest: +ELLIPSIS
     ...
     [..., ..., ..., ...]
@@ -19,8 +19,8 @@ Beware of page numbers. slate.PDF objects start at 0.
     ...
     >>> "Hello, I'm page three." in doc[2]
     True
- 
-Blank pages are empty strings: 
+
+Blank pages are empty strings:
 
     >>> doc[1]
     ''
@@ -35,14 +35,14 @@ remove unnecessary whitespace, e.g. '  \n  \x0c' => ' '.
     False
 
 Passwords are supported. Use them as the second argument
-of your intialization. Currently, UTF-8 encoding is 
-hard-coded. If you would like to access more advanced 
+of your intialization. Currently, UTF-8 encoding is
+hard-coded. If you would like to access more advanced
 features, you should take a look at the PDFMiner API[2].
 
     >>> with open('protected.pdf', 'rb') as f:
     ...    PDF(f, 'a')[0].strip()
     'Chamber of secrets.'
-    
+
 
   [1] http://www.unixuser.org/~euske/python/pdfminer/index.html
   [2] http://www.unixuser.org/~euske/python/pdfminer/programming.html
@@ -63,4 +63,4 @@ features, you should take a look at the PDFMiner API[2].
 #You should have received a copy of the GNU General Public License
 #along with slate.  If not, see <http://www.gnu.org/licenses/>.
 
-from slate import PDF
+from .classes import PDF

--- a/src/slate/classes.py
+++ b/src/slate/classes.py
@@ -1,7 +1,11 @@
-try:
-    from cStringIO import StringIO
-except ImportError:
+import sys
+PYTHON_3 = sys.version_info[0] == 3
+if PYTHON_3:
+    from io import StringIO
+else:
     from StringIO import StringIO
+    from pdfminer.pdfpage import PDFPage
+
 
 from pdfminer.pdfparser import PDFParser
 from pdfminer.pdfinterp import PDFResourceManager
@@ -13,16 +17,16 @@ try:
 except ImportError:
     from pdfminer.pdfdocument import PDFDocument
 
-from pdfminer.pdfpage import PDFPage
 
-import utils
+from slate import utils
 
 __all__ = ['PDF']
 
 class PDFPageInterpreter(PI):
     def process_page(self, page):
-        if 1 <= self.debug:
-            print >>stderr, 'Processing page: %r' % page
+        if hasattr(self, 'debug'):
+            if 1 <= self.debug:
+                print >>stderr, 'Processing page: %r' % page
         (x0,y0,x1,y1) = page.mediabox
         if page.rotate == 90:
             ctm = (0,-1,1,0, -y0,x1)
@@ -42,20 +46,34 @@ class PDFPageInterpreter(PI):
 class PDF(list):
     def __init__(self, file, password='', just_text=1, check_extractable=True):
         self.parser = PDFParser(file)
-        self.doc = PDFDocument(self.parser, password)
+
+        if PYTHON_3:
+            self.doc = PDFDocument()
+            self.parser.set_document(self.doc)
+            self.doc.set_parser(self.parser)
+            self.doc.initialize(password)
+        else:
+            self.doc = PDFDocument(self.parser, password)
+
         if not check_extractable or self.doc.is_extractable:
             self.resmgr = PDFResourceManager()
             self.device = TextConverter(self.resmgr, outfp=StringIO())
             self.interpreter = PDFPageInterpreter(
                self.resmgr, self.device)
-            for page in PDFPage.create_pages(self.doc):
+
+            if PYTHON_3:
+                page_generator = self.doc.get_pages()
+            else:
+                page_generator = PDFPage.create_pages(self.doc)
+
+            for page in page_generator:
                 self.append(self.interpreter.process_page(page))
             self.metadata = self.doc.info
         if just_text:
             self._cleanup()
 
     def _cleanup(self):
-        """ 
+        """
         Frees lots of non-textual information, such as the fonts
         and images and the objects that were needed to parse the
         PDF.
@@ -67,7 +85,7 @@ class PDF(list):
         self.interpreter = None
 
     def text(self, clean=True):
-        """ 
+        """
         Returns the text of the PDF as a single string.
         Options:
 
@@ -77,4 +95,4 @@ class PDF(list):
         if clean:
             return utils.normalise_whitespace(''.join(self))
         else:
-            return ''.join(self) 
+            return ''.join(self)

--- a/src/slate/test_slate.py
+++ b/src/slate/test_slate.py
@@ -1,12 +1,12 @@
-""" 
-  Tests for slate 
+"""
+  Tests for slate
   http://pypi.python.org/slate
 
   Expected to be used with py.test:
   http://codespeak.net/py/dist/test/index.html
 """
 
-from slate import PDF
+from .classes import PDF
 
 def pytest_funcarg__doc(request):
     with open('example.pdf', 'rb') as f:

--- a/src/slate/unittests.py
+++ b/src/slate/unittests.py
@@ -1,0 +1,28 @@
+import unittest
+
+from slate import PDF
+
+class TestSlate(unittest.TestCase):
+    def setUp(self):
+        with open('example.pdf', 'rb') as f:
+            self.doc = PDF(f)
+        with open('protected.pdf', 'rb') as f:
+            self.passwd = PDF(f, 'a')
+
+    def test_basic(self):
+        assert self.doc[0] == 'This is a test.\x0c'
+
+    def test_metadata_extraction(self):
+        assert self.doc.metadata
+
+    def test_text_method(self):
+        assert "This is a test" in self.doc.text()
+
+    def test_text_method_unclean(self):
+        assert '\x0c' in self.doc.text(clean=0)
+
+    def test_password(self):
+        assert self.passwd[0] == "Chamber of secrets.\x0c"
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I can't promise that this is elegant, but it seems to take care of #18. unittests.py passes in Python2.7 and Python 3.5.

Changed slate.py --> classes.py while fumbling around with Python 3's #$(_(_!&##! relative import crap.
