### PR TITLE
Fix text carrier-over between pages. Fix tests.

### DIFF
--- a/src/slate/classes.py
+++ b/src/slate/classes.py
@@ -41,6 +41,7 @@ class PDFPageInterpreter(PI):
         else:
             ctm = (1,0,0,1, -x0,-y0)
         self.device.outfp.seek(0)
+        self.device.outfp.truncate(0)
         self.device.begin_page(page, ctm)
         self.render_contents(page.resources, page.contents, ctm=ctm)
         self.device.end_page(page)

--- a/src/slate/unittests.py
+++ b/src/slate/unittests.py
@@ -10,7 +10,10 @@ class TestSlate(unittest.TestCase):
             self.passwd = PDF(f, 'a')
 
     def test_basic(self):
-        assert self.doc[0] == 'This is a test.\x0c'
+        assert self.doc[0] == 'This is a test.\n\n\x0c'
+
+    def test_no_text_carry_over(self):
+        assert self.doc[1] == '\x0c'
 
     def test_metadata_extraction(self):
         assert self.doc.metadata
@@ -22,7 +25,7 @@ class TestSlate(unittest.TestCase):
         assert '\x0c' in self.doc.text(clean=0)
 
     def test_password(self):
-        assert self.passwd[0] == "Chamber of secrets.\x0c"
+        assert self.passwd[0] == "Chamber of secrets.\n\n\x0c"
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
1. Fixed tests by including newlines from extracted documents
2. Added test to illustrate merge bug from commit
43614f2716fb6020d31bfde64712636b084c417b in which uncleared buffer
carries text between pages
3. Added clearing of buffer that also addresses issue #21 in the prior
codebase