### PR TITLE
Fix slate for Python 3.4+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist/*
 *.pyc
 *.pyo
 slate.egg-info
+.cache
+.*.swp

--- a/README.rst
+++ b/README.rst
@@ -8,24 +8,24 @@ text from PDF files. It depends on the PDFMiner package.
 
 Slate provides one class, PDF. PDF takes a file-like object and
 will extract all text from the document, presentating each page
-as a string of text:
+as a string of text::
 
-  >>> with open('example.pdf') as f:
-  ...    doc = slate.PDF(f)
-  ...
-  >>> doc 
-  [..., ..., ...]
-  >>> doc[1]
-  'Text from page 2...'
+    >>> with open('example.pdf') as f:
+    ...    doc = slate.PDF(f)
+    ...
+    >>> doc 
+    [..., ..., ...]
+    >>> doc[1]
+    'Text from page 2...'
 
 If your pdf is password protected, pass the password as the
-second argument:
+second argument::
 
-  >>> with open('secrets.pdf') as f:
-  ...     doc = slate.PDF(f, 'password')
-  ...
-  >>> doc[0]
-  "My mother doesn't know this, but..."
+    >>> with open('secrets.pdf') as f:
+    ...     doc = slate.PDF(f, 'password')
+    ...
+    >>> doc[0]
+    "My mother doesn't know this, but..."
 
 More complex operations
 -----------------------
@@ -37,10 +37,10 @@ information, then take some time to learn the PDFMiner API.
 What is wrong with PDFMiner?
 ----------------------------
 
-  1. Getting simple things done, like extracting the text
-     is quite complex. The program is not designed to return
-     Python objects, which makes interfacing things irritating.
-  2. It's an extremely complete set of tools, with multiple 
-     and moderately  steep learning curves.
-  3. It's not written with hackability in mind.
+1. Getting simple things done, like extracting the text
+ is quite complex. The program is not designed to return
+ Python objects, which makes interfacing things irritating.
+2. It's an extremely complete set of tools, with multiple 
+ and moderately  steep learning curves.
+3. It's not written with hackability in mind.
 

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Slate provides one class, PDF. PDF takes a file-like object and
 will extract all text from the document, presentating each page
 as a string of text::
 
-    >>> with open('example.pdf') as f:
+    >>> with open('example.pdf', 'rb') as f:
     ...    doc = slate.PDF(f)
     ...
     >>> doc 
@@ -21,7 +21,7 @@ as a string of text::
 If your pdf is password protected, pass the password as the
 second argument::
 
-    >>> with open('secrets.pdf') as f:
+    >>> with open('secrets.pdf', 'rb') as f:
     ...     doc = slate.PDF(f, 'password')
     ...
     >>> doc[0]
@@ -38,9 +38,9 @@ What is wrong with PDFMiner?
 ----------------------------
 
 1. Getting simple things done, like extracting the text
- is quite complex. The program is not designed to return
- Python objects, which makes interfacing things irritating.
+   is quite complex. The program is not designed to return
+   Python objects, which makes interfacing things irritating.
 2. It's an extremely complete set of tools, with multiple 
- and moderately  steep learning curves.
+   and moderately  steep learning curves.
 3. It's not written with hackability in mind.
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='slate',
       packages=find_packages('src'),
       package_dir={'': 'src'},
       requires=[pdfminer],
-      install_requires=['distribute', pdfminer],
+      install_requires=[pdfminer],
       classifiers= [
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ if PYTHON_3:
 else:
     pdfminer = 'pdfminer'
 
-with open('README') as f:
+with open('README.rst') as f:
     long_description = f.read()
 
 setup(name='slate',

--- a/src/slate/classes.py
+++ b/src/slate/classes.py
@@ -22,7 +22,7 @@ try:
     from pdfminer.pdfparser import PDFPage
 except ImportError:
     from pdfminer.pdfpage import PDFPage
-from . import  utils
+from . import utils
 
 __all__ = ['PDF']
 

--- a/src/slate/classes.py
+++ b/src/slate/classes.py
@@ -22,7 +22,10 @@ try:
     from pdfminer.pdfparser import PDFPage
 except ImportError:
     from pdfminer.pdfpage import PDFPage
-import utils
+if PYTHON_3:
+    import slate.utils as utils
+else:
+    import utils
 
 __all__ = ['PDF']
 

--- a/src/slate/classes.py
+++ b/src/slate/classes.py
@@ -22,10 +22,7 @@ try:
     from pdfminer.pdfparser import PDFPage
 except ImportError:
     from pdfminer.pdfpage import PDFPage
-if PYTHON_3:
-    import slate.utils as utils
-else:
-    import utils
+from . import  utils
 
 __all__ = ['PDF']
 

--- a/src/slate/test_slate.py
+++ b/src/slate/test_slate.py
@@ -12,7 +12,7 @@ PYTHON_3 = sys.version_info[0] == 3
 import os
 
 if PYTHON_3:
-    from .classes import PDF
+    from slate.classes import PDF
 else:
     from classes import PDF
 

--- a/src/slate/test_slate.py
+++ b/src/slate/test_slate.py
@@ -6,22 +6,18 @@
   http://codespeak.net/py/dist/test/index.html
 """
 
-import sys
-PYTHON_3 = sys.version_info[0] == 3
-
 import os
+import pytest
 
-if PYTHON_3:
-    from slate.classes import PDF
-else:
-    from classes import PDF
+from .classes import PDF
 
-
-def pytest_funcarg__doc(request):
+@pytest.fixture
+def doc():
     with open(get_pdf_path('example.pdf'), 'rb') as f:
         return PDF(f)
 
-def pytest_funcarg__passwd(request):
+@pytest.fixture
+def passwd():
     with open(get_pdf_path('protected.pdf'), 'rb') as f:
         return PDF(f, 'a')
 

--- a/src/slate/test_slate.py
+++ b/src/slate/test_slate.py
@@ -6,14 +6,23 @@
   http://codespeak.net/py/dist/test/index.html
 """
 
-from classes import PDF
+import sys
+PYTHON_3 = sys.version_info[0] == 3
+
+import os
+
+if PYTHON_3:
+    from .classes import PDF
+else:
+    from classes import PDF
+
 
 def pytest_funcarg__doc(request):
-    with open('example.pdf', 'rb') as f:
+    with open(get_pdf_path('example.pdf'), 'rb') as f:
         return PDF(f)
 
 def pytest_funcarg__passwd(request):
-    with open('protected.pdf') as f:
+    with open(get_pdf_path('protected.pdf'), 'rb') as f:
         return PDF(f, 'a')
 
 def test_basic(doc):
@@ -30,3 +39,10 @@ def test_text_method_unclean(doc):
 
 def test_password(passwd):
     assert passwd[0] == "Chamber of secrets.\n\n\x0c"
+
+def get_pdf_path(pdf_file):
+    return os.path.join(
+        os.path.dirname(__file__),
+        pdf_file)
+
+

--- a/src/slate/unittests.py
+++ b/src/slate/unittests.py
@@ -1,12 +1,13 @@
 import unittest
 
+import os
 from slate import PDF
 
 class TestSlate(unittest.TestCase):
     def setUp(self):
-        with open('example.pdf', 'rb') as f:
+        with open(get_pdf_path('example.pdf'), 'rb') as f:
             self.doc = PDF(f)
-        with open('protected.pdf', 'rb') as f:
+        with open(get_pdf_path('protected.pdf'), 'rb') as f:
             self.passwd = PDF(f, 'a')
 
     def test_basic(self):
@@ -26,6 +27,12 @@ class TestSlate(unittest.TestCase):
 
     def test_password(self):
         assert self.passwd[0] == "Chamber of secrets.\n\n\x0c"
+
+
+def get_pdf_path(pdf_file):
+    return os.path.join(
+        os.path.dirname(__file__),
+        pdf_file)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I faced some issues while using slate with  Python 3.4 and 3.5. It is due to the differences in relative import between python 2 and python 3 which lead to an error in classes.py.

I also updated the tests, the readme and setup.py.

I did not take time to test with Python 2.7 and Python 3 releases prior 3.4 though.

I hope you'll be able to merge. BTW, thanks for your work on this lib!
