### PR TITLE
Removing distribute dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='slate',
       packages=find_packages('src'),
       package_dir={'': 'src'},
       requires=[pdfminer],
-      install_requires=['distribute', pdfminer],
+      install_requires=['setuptools', pdfminer],
       classifiers= [
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Distribute is deprecated and, although it should be tracking `setuptools` for compatibility, it's not keeping up to date. Hence this install is broken in python 3.6. There's no reason to use `distribute` over `setuptools` at this point.

I tested this by installing and running OCR on a few documents.