### PR TITLE
fixed importing of 'utils' in 'slate.classes' so that it wouldn't clobber when users have another module called 'utils'

### DIFF
--- a/src/slate/classes.py
+++ b/src/slate/classes.py
@@ -22,7 +22,7 @@ try:
     from pdfminer.pdfparser import PDFPage
 except ImportError:
     from pdfminer.pdfpage import PDFPage
-import utils
+import slate.utils as utils
 
 __all__ = ['PDF']
 


### PR DESCRIPTION
- I kept it simple for ease of review and merging
- my friend had a namespace clobber - slate's `insert utils` imported a different `utils`
- I don't know best practices or whether `import slate.utils as utils` is the best solution, but using such an import never caused issues for me. `from . import utils` can cause issues when trying to run a code file directly (e.g. `python classes.py` from the command line) vs importing a module that contains such `from . import utils` statements from other python code.