### PR TITLE
fixed importing of 'utils' in 'slate.classes' so that it wouldn't clobber when users have another module called 'utils'

### DIFF
--- a/src/slate/classes.py
+++ b/src/slate/classes.py
@@ -22,7 +22,7 @@ try:
     from pdfminer.pdfparser import PDFPage
 except ImportError:
     from pdfminer.pdfpage import PDFPage
-import utils
+from slate import utils
 
 __all__ = ['PDF']
 


### PR DESCRIPTION
this is a better version than my previous #44, following that described by https://github.com/timClicks/slate/pull/32#issuecomment-224019698

- I kept it simple for ease of review and merging
- my friend had a namespace clobber - slate's `insert utils` imported a different `utils`
- the import statement `from . import utils` isn't compatible in all situations - out of these two situations, it usually only works in one of them: running the program which contains `from . import utils` directly from the command line (e.g. `python classes.py`) vs importing the file which contains `from . import utils` as a module from other python code.

my original solution was `import slate.utils as utils`, but I think `from slate import utils` as described by @mvherweg in https://github.com/timClicks/slate/pull/32#issuecomment-224019698 is a better solution.